### PR TITLE
Jetson

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.18)
 project(COVERAGE CUDA CXX C)
 
+if(POLICY CMP0146)
+    cmake_policy(SET CMP0146 OLD)
+endif()
+
 # set C++ standard
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -49,7 +53,7 @@ add_executable(${PROJECT_NAME} ${SOURCES} ${HEADERS})
 # set CUDA architectures
 set_target_properties(${PROJECT_NAME} PROPERTIES
     CUDA_SEPARABLE_COMPILATION ON
-    CUDA_ARCHITECTURES "89"  # adjust according to the architecture of GPUs
+    CUDA_ARCHITECTURES "72"  # adjust according to the architecture of GPUs
 )
 
 # link cuda lib

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,7 @@ target_link_libraries(${PROJECT_NAME}
     stdc++fs
     cuda
     cudart
+    cublas
     ${CUDA_LIBRARIES}
     ${OpenCV_LIBS}
     ${EIGEN3_LIBS}

--- a/include/camera.h
+++ b/include/camera.h
@@ -1,6 +1,9 @@
 #ifndef CAM_H
 #define CAM_H
 
+#include <iostream>
+#include <sstream>
+#include <fstream>
 #include <string>
 #include <vector>
 #include <opencv2/opencv.hpp>

--- a/include/cudaCoverage.cuh
+++ b/include/cudaCoverage.cuh
@@ -49,7 +49,7 @@ __device__ bool is_point_visible(
  * @param intrinsics                camera intrinsics
  * @param d_extrinsics_array        camera extrinsics
  * @param d_points_array            3D points
- * @param d_depth_maps                array of depth maps
+ * @param d_depth_maps              array of depth maps
  * @param d_visibility_matrix       output visibility matrix
  * @param num_cameras               number of cameras
  * @param num_points                number of points
@@ -59,7 +59,7 @@ __global__ void generateVisibilityMatrixKernel(
     const float* __restrict__ d_extrinsics_array, // camera extrinsics
     const float3* __restrict__ d_points_array, // 3D points
     const float* __restrict__ d_depth_maps, // depth maps array
-    unsigned char* __restrict__ d_visibility_matrix, // output visibility matrix
+    float* __restrict__ d_visibility_matrix, // output visibility matrix
     int num_cameras, // number of cameras
     int num_points   // number of points
     ); 
@@ -78,8 +78,8 @@ __global__ void generateVisibilityMatrixKernel(
  * @param num_points                     number of points
  */
 __global__ void findCandidateCameraKernel(
-    const unsigned char* __restrict__ d_visibility_matrix,
-    const int* __restrict__ d_camera_visible_points_count,
+    float* __restrict__ d_visibility_matrix,
+    const float* __restrict__ d_camera_visible_points_count,
     int* __restrict__ d_point_candidate_camera_index,
     unsigned int* __restrict__ d_candidate_camera_mask, // This pointer points to pinned memory accessible by CPU
     int num_cameras,
@@ -107,7 +107,7 @@ void getVisibilityMatrixKernel(
     const float* depth_maps,  // depth maps' array, the sequence is: depth_map number, rows, cols
     int num_cameras,          // camera number, also group number of extrinsics array
     int num_points,           // point number, also length of points array
-    unsigned char* visibility_matrix,   // now leave it for debugging, for better design, it shouldn't be here, just pass the data on GPU, do not back load the data to CPU
+    float* visibility_matrix,   // now leave it for debugging, for better design, it shouldn't be here, just pass the data on GPU, do not back load the data to CPU
     unsigned int* candidate_camera_mask, // candidate camera mask, each element is 1 if the camera is a candidate, 0 otherwise, the size is num_cameras.
     int* point_candidate_camera_index // point candidate camera index, each element is the index of the candidate camera for the point, -1 means no camera is chosen for the point, the size is num_points.
 );

--- a/include/cudaCoverage.cuh
+++ b/include/cudaCoverage.cuh
@@ -98,6 +98,7 @@ __global__ void findCandidateCameraKernel(
  * @param num_points                number of points
  * @param visibility_matrix         output visibility matrix, from GPU to CPU
  * @param candidate_camera_mask     output candidate camera mask, the size is exactly the same as the num_cameras
+ * @param point_candidate_camera_index output point candidate camera index, each element is the index of the candidate camera for the point, -1 means no camera is chosen for the point, the size is num_points.
  */
 void getVisibilityMatrixKernel(
     const float* intrinsic,   // camera intrinsic, in the format of a float*, (0, 1, 2, 3, 4, 5) -> (fx, fy, cx, cy, img_width, img_height)
@@ -107,7 +108,8 @@ void getVisibilityMatrixKernel(
     int num_cameras,          // camera number, also group number of extrinsics array
     int num_points,           // point number, also length of points array
     unsigned char* visibility_matrix,   // now leave it for debugging, for better design, it shouldn't be here, just pass the data on GPU, do not back load the data to CPU
-    unsigned int* candidate_camera_mask // candidate camera mask, each element is 1 if the camera is a candidate, 0 otherwise, the size is num_cameras.
+    unsigned int* candidate_camera_mask, // candidate camera mask, each element is 1 if the camera is a candidate, 0 otherwise, the size is num_cameras.
+    int* point_candidate_camera_index // point candidate camera index, each element is the index of the candidate camera for the point, -1 means no camera is chosen for the point, the size is num_points.
 );
 
 } // namespace Coverage

--- a/include/cudaUtils.cuh
+++ b/include/cudaUtils.cuh
@@ -15,4 +15,15 @@
         }                                                                         \
     } while (0)
 
+// CUBLAS error checking macro
+#define CUBLAS_CHECK(call)                                                        \
+    do {                                                                          \
+        cublasStatus_t status = call;                                             \
+        if (status != CUBLAS_STATUS_SUCCESS) {                                    \
+            fprintf(stderr, "CUBLAS error at %s:%d - status %d\n", __FILE__, __LINE__, \
+                    status);                                                      \
+            exit(EXIT_FAILURE);                                                   \
+        }                                                                         \
+    } while (0)
+
 #endif // CUDA_UTILS_COVERAGE

--- a/include/depth.h
+++ b/include/depth.h
@@ -4,6 +4,9 @@
 #include <vector>
 #include <opencv2/opencv.hpp>
 
+#include <cuda_runtime.h>
+#include "cudaUtils.cuh"
+
 namespace Depth {
 
 /**
@@ -26,12 +29,16 @@ public:
     Depth();
     ~Depth() {};
     void loadDepthMaps(const std::string& depth_map_file_folder); // load all the depth maps from the given folder
+    void loadDepthMaps_jetson(const std::string& depth_map_file_folder); // load all the depth maps from the given folder, jetson version
     float* convertToFloat();
 
 public:
     std::vector<cv::Mat> depth_maps_;
-    int depth_map_num_; // number of depth maps, also number of cameras
+    int depth_map_num_; // number of depth maps, also number of cameras, also activated in jetson version
     float* depth_maps_float_;
+
+    // for jetson design and usage
+    float* unified_float_depth_maps_; // allocated in unified memory
 };
 
 } // namespace Depth

--- a/include/mesh.h
+++ b/include/mesh.h
@@ -11,13 +11,21 @@ public:
     Mesh();
     ~Mesh() {};
     void loadFromFile(const std::string& filename);
+    void loadFromFile_jetson(const std::string& filename);
     // other mesh related methods
     std::vector<float3>& getVertexes() {
         return vertices_;
     };
-private:
+
+public:
     // mesh data members
     std::vector<float3> vertices_; 
+    // because the mechanism of rply lib, this is a unavoidable data member that needs to be kept, even in jetson version
+    // however, no need to remove it, even in 100w points mesh, the memory usage is around 10MB, which is acceptable
+
+    // for jetson design and usage
+    float3* unified_float_vertices_; // allocated in unified memory
+    int vertex_num_; // number of vertices, only activated in jetson version
 };
 
 } // namespace MeshProcessing

--- a/launch.sh
+++ b/launch.sh
@@ -3,7 +3,7 @@
 # 1. the data_path is the path to the data, and the data is carefully prepared
 # 2. the mvs-texture is built, and set the path to the mvs-texture in the script
 # 3. the cuda_coverage is built and run successfully
-export data_path="/home/hmy/cuda_coverage/data/underground_large"
+export data_path="/home/jetson/Coverage_computation_cuda/data/underground_large"
 echo "data_path: $data_path"
 # run a coverage GPU program
 ./build/COVERAGE -m $data_path/mesh/filtered_mesh.ply -i $data_path/intrinsic.log -e $data_path/traj.log -d $data_path/depth -p $data_path/image
@@ -15,7 +15,7 @@ if [ -d "tex_result" ]; then
 fi
 mkdir -p tex_obj/result
 # run mvs-texture
-/home/hmy/mvs-texturing/build/apps/texrecon/texrecon \
+/home/jetson/mvs-texturing/build/apps/texrecon/texrecon \
     --smoothness_term=potts \
     --tone_mapping=gamma \
     --outlier_removal=gauss_damping \

--- a/launch_debug.sh
+++ b/launch_debug.sh
@@ -3,7 +3,7 @@
 # 1. the data_path is the path to the data, and the data is carefully prepared
 # 2. the mvs-texture is built, and set the path to the mvs-texture in the script
 # 3. the cuda_coverage is built and run successfully
-export data_path="/home/jetson/Coverage_computation_cuda/data/underground_lighter"
+export data_path="/home/jetson/Coverage_computation_cuda/data/underground_large"
 echo "data_path: $data_path"
 # run a coverage GPU program
 ./build/COVERAGE -m $data_path/mesh/filtered_mesh.ply -i $data_path/intrinsic.log -e $data_path/traj.log -d $data_path/depth -p $data_path/image

--- a/launch_debug.sh
+++ b/launch_debug.sh
@@ -3,7 +3,7 @@
 # 1. the data_path is the path to the data, and the data is carefully prepared
 # 2. the mvs-texture is built, and set the path to the mvs-texture in the script
 # 3. the cuda_coverage is built and run successfully
-export data_path="/home/jetson/Coverage_computation_cuda/data/underground_large"
+export data_path="/home/jetson/Coverage_computation_cuda/data/underground_lighter"
 echo "data_path: $data_path"
 # run a coverage GPU program
 ./build/COVERAGE -m $data_path/mesh/filtered_mesh.ply -i $data_path/intrinsic.log -e $data_path/traj.log -d $data_path/depth -p $data_path/image

--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -38,6 +38,37 @@ void Cam::loadIntrinsic(const std::string& intrinsic_file) {
     file.close();
 }
 
+void Cam::loadIntrinsic_jetson(const std::string& intrinsic_file) {
+    std::ifstream file(intrinsic_file);
+    if (!file.is_open()) {
+        throw std::runtime_error("Could not open intrinsic file: " + intrinsic_file);
+    }
+
+    std::string line;
+    CUDA_CHECK(cudaMallocManaged(&this->unified_float_intrinsic_, sizeof(float) * 6));
+    while (std::getline(file, line)) {
+        std::istringstream iss(line);
+        std::string key;
+        float value;
+        if (iss >> key >> value) {
+            if (key == "fx") {
+                this->unified_float_intrinsic_[0] = value;
+            } else if (key == "fy") {
+                this->unified_float_intrinsic_[1] = value;
+            } else if (key == "cx") {
+                this->unified_float_intrinsic_[2] = value;
+            } else if (key == "cy") {
+                this->unified_float_intrinsic_[3] = value;
+            } else if (key == "width") {
+                this->unified_float_intrinsic_[4] = value;
+            } else if (key == "height") {
+                this->unified_float_intrinsic_[5] = value;
+            }
+        }
+    }
+    file.close();
+}
+
 void Cam::loadExtrinsics_colormap(const std::string& extrinsic_file) {
     std::ifstream file(extrinsic_file);
     if (!file.is_open()) {
@@ -80,6 +111,83 @@ void Cam::loadExtrinsics_colormap(const std::string& extrinsic_file) {
     }
 
     file.close();
+}
+
+void Cam::loadExtrinsics_colormap_jetson(const std::string& extrinsic_file) {
+    std::ifstream file(extrinsic_file);
+    if (!file.is_open()) {
+        throw std::runtime_error("Could not open extrinsic file: " + extrinsic_file);
+    }
+
+    std::string line;
+    std::vector<Extrinsic_jetson> extrinsics_jetson;
+    int line_num = 0;
+    float t00, t01, t02, t03, t10, t11, t12, t13, t20, t21, t22, t23, t30, t31, t32, t33;
+    while (std::getline(file, line)) {
+        std::istringstream iss(line);
+        switch (line_num % 5) {
+            case 0:
+                break;
+            case 1:
+                iss >> t00 >> t01 >> t02 >> t03;
+                break;
+            case 2:
+                iss >> t10 >> t11 >> t12 >> t13;
+                break;
+            case 3:
+                iss >> t20 >> t21 >> t22 >> t23;
+                break;
+            case 4:
+                iss >> t30 >> t31 >> t32 >> t33;
+                
+                Eigen::Matrix4f T_wc;
+                T_wc << t00, t01, t02, t03, t10, t11, t12, t13, t20, t21, t22, t23, t30, t31, t32, t33;
+                Eigen::Matrix4f T_cw = T_wc.inverse();
+                Extrinsic_jetson extrinsic_jetson;
+                extrinsic_jetson.t00 = T_cw(0, 0);
+                extrinsic_jetson.t01 = T_cw(0, 1);
+                extrinsic_jetson.t02 = T_cw(0, 2);
+                extrinsic_jetson.t03 = T_cw(0, 3);
+                extrinsic_jetson.t10 = T_cw(1, 0);
+                extrinsic_jetson.t11 = T_cw(1, 1);
+                extrinsic_jetson.t12 = T_cw(1, 2);
+                extrinsic_jetson.t13 = T_cw(1, 3);
+                extrinsic_jetson.t20 = T_cw(2, 0);
+                extrinsic_jetson.t21 = T_cw(2, 1);
+                extrinsic_jetson.t22 = T_cw(2, 2);
+                extrinsic_jetson.t23 = T_cw(2, 3);
+
+                extrinsics_jetson.push_back(extrinsic_jetson);
+                /* for debug */
+                /* std::cout << "Extrinsic " << line_num / 5 << ":\n" << extrinsic.T_wc << std::endl; */
+                break;
+        }
+        line_num++;
+    }
+
+    file.close();
+
+    // allocate unified memory for extrinsics_jetson
+    this->number_extrinsics = extrinsics_jetson.size(); // number of extrinsics
+    CUDA_CHECK(cudaMallocManaged(&this->unified_float_extrinsic_, sizeof(float) * 12 * this->number_extrinsics));
+    for (int i = 0; i < this->number_extrinsics; i++) {
+        this->unified_float_extrinsic_[i * 12 + 0] = extrinsics_jetson[i].t00;
+        this->unified_float_extrinsic_[i * 12 + 1] = extrinsics_jetson[i].t01;
+        this->unified_float_extrinsic_[i * 12 + 2] = extrinsics_jetson[i].t02;
+        this->unified_float_extrinsic_[i * 12 + 3] = extrinsics_jetson[i].t03;
+        this->unified_float_extrinsic_[i * 12 + 4] = extrinsics_jetson[i].t10;
+        this->unified_float_extrinsic_[i * 12 + 5] = extrinsics_jetson[i].t11;
+        this->unified_float_extrinsic_[i * 12 + 6] = extrinsics_jetson[i].t12;
+        this->unified_float_extrinsic_[i * 12 + 7] = extrinsics_jetson[i].t13;
+        this->unified_float_extrinsic_[i * 12 + 8] = extrinsics_jetson[i].t20;
+        this->unified_float_extrinsic_[i * 12 + 9] = extrinsics_jetson[i].t21;
+        this->unified_float_extrinsic_[i * 12 + 10] = extrinsics_jetson[i].t22;
+        this->unified_float_extrinsic_[i * 12 + 11] = extrinsics_jetson[i].t23;
+    }
+
+    // free the extrinsics_jetson as soon as possible
+    extrinsics_jetson.clear();
+    extrinsics_jetson.shrink_to_fit();
 }
 
 };

--- a/src/cudaCoverage.cu
+++ b/src/cudaCoverage.cu
@@ -1,11 +1,14 @@
 #include "cudaCoverage.cuh"
 #include "cudaUtils.cuh"
+
+#include <cublas_v2.h>
+
 #include <stdio.h>
 
-#include <thrust/host_vector.h>
-#include <thrust/device_vector.h>
-#include <thrust/reduce.h>      // For thrust::reduce
-#include <thrust/functional.h>  // For thrust::plus
+// #include <thrust/host_vector.h>
+// #include <thrust/device_vector.h>
+// #include <thrust/reduce.h>      // For thrust::reduce
+// #include <thrust/functional.h>  // For thrust::plus
 
 void Coverage::getVisibilityMatrixKernel(
     const float* intrinsic,   // camera intrinsic, in the format of a float*, (0, 1, 2, 3, 4, 5) -> (fx, fy, cx, cy, img_width, img_height)
@@ -14,7 +17,7 @@ void Coverage::getVisibilityMatrixKernel(
     const float* depth_maps,  // depth maps' array, the sequence is: depth_map number, rows, cols
     int num_cameras,          // camera number, also group number of extrinsics array
     int num_points,           // point number, also length of points array
-    unsigned char* visibility_matrix, // now leave it for debugging, for better design, it shouldn't be here, just pass the data on GPU, do not back load the data to CPU
+    float* visibility_matrix, // now leave it for debugging, for better design, it shouldn't be here, just pass the data on GPU, do not back load the data to CPU
     unsigned int* candidate_camera_mask, // candidate camera mask, each element is 1 if the camera is a candidate, 0 otherwise, the size is num_cameras.
     int* point_candidate_camera_index // point candidate camera index, each element is the index of the candidate camera for the point, -1 means no camera is chosen for the point, the size is num_points.
 ) {
@@ -43,32 +46,81 @@ void Coverage::getVisibilityMatrixKernel(
     CUDA_CHECK(cudaEventElapsedTime(&elapsedTime, start, stop));
     printf("Kernel execution time for generating visibility matrix: %f ms\n", elapsedTime);
 
-    // 2. count the number of visible points for each camera using thrust
-    thrust::device_vector<int> d_camera_visible_points_count_thrust(num_cameras);
-    std::cout << "\nStarting Thrust to calculate camera visible points count (using existing GPU memory)..." << std::endl;
+    // // 2. count the number of visible points for each camera using thrust
+    // thrust::device_vector<int> d_camera_visible_points_count_thrust(num_cameras);
+    // std::cout << "\nStarting Thrust to calculate camera visible points count (using existing GPU memory)..." << std::endl;
 
-    cudaEvent_t start_thrust_count, stop_thrust_count;
-    CUDA_CHECK(cudaEventCreate(&start_thrust_count));
-    CUDA_CHECK(cudaEventCreate(&stop_thrust_count));
+    // cudaEvent_t start_thrust_count, stop_thrust_count;
+    // CUDA_CHECK(cudaEventCreate(&start_thrust_count));
+    // CUDA_CHECK(cudaEventCreate(&stop_thrust_count));
 
-    CUDA_CHECK(cudaEventRecord(start_thrust_count));
-    // Loop through each camera (row) and use thrust::reduce to sum the visible points
-    for (int camera_index = 0; camera_index < num_cameras; camera_index++) {
-        thrust::device_ptr<const unsigned char> row_start = thrust::device_pointer_cast(visibility_matrix + camera_index * num_points);
-        thrust::device_ptr<const unsigned char> row_end = row_start + num_points;
+    // CUDA_CHECK(cudaEventRecord(start_thrust_count));
+    // // Loop through each camera (row) and use thrust::reduce to sum the visible points
+    // for (int camera_index = 0; camera_index < num_cameras; camera_index++) {
+    //     thrust::device_ptr<const float> row_start = thrust::device_pointer_cast(visibility_matrix + camera_index * num_points);
+    //     thrust::device_ptr<const float> row_end = row_start + num_points;
 
-        int sum_for_camera = thrust::reduce(row_start, row_end, 0, thrust::plus<int>());
-        d_camera_visible_points_count_thrust[camera_index] = sum_for_camera;   
-    }
-    CUDA_CHECK(cudaEventRecord(stop_thrust_count));
-    CUDA_CHECK(cudaEventSynchronize(stop_thrust_count));
+    //     int sum_for_camera = thrust::reduce(row_start, row_end, 0, thrust::plus<int>());
+    //     d_camera_visible_points_count_thrust[camera_index] = sum_for_camera;   
+    // }
+    // CUDA_CHECK(cudaEventRecord(stop_thrust_count));
+    // CUDA_CHECK(cudaEventSynchronize(stop_thrust_count));
     
-    float thrust_count_milliseconds = 0;
-    CUDA_CHECK(cudaEventElapsedTime(&thrust_count_milliseconds, start_thrust_count, stop_thrust_count));
-    std::cout << "Thrust calculateCameraVisiblePointsCount execution time: " << thrust_count_milliseconds << " ms" << std::endl;
+    // float thrust_count_milliseconds = 0;
+    // CUDA_CHECK(cudaEventElapsedTime(&thrust_count_milliseconds, start_thrust_count, stop_thrust_count));
+    // std::cout << "Thrust calculateCameraVisiblePointsCount execution time: " << thrust_count_milliseconds << " ms" << std::endl;
 
-    // get the raw pointer of camera visible points count array on GPU, the size is num_cameras
-    int* d_camera_visible_points_count_ptr = thrust::raw_pointer_cast(d_camera_visible_points_count_thrust.data());
+    // // get the raw pointer of camera visible points count array on GPU, the size is num_cameras
+    // int* d_camera_visible_points_count_ptr = thrust::raw_pointer_cast(d_camera_visible_points_count_thrust.data());
+
+    // 2. do the matrix multiplication using cublas.
+    // create a vector for matrix reduction
+    float *vector_reduction;
+    CUDA_CHECK(cudaMallocManaged(&vector_reduction, num_points * sizeof(float)));
+    CUDA_CHECK(cudaMemset(vector_reduction, 1, num_points * sizeof(float)));
+
+    float *d_camera_visible_points_count_ptr;
+    CUDA_CHECK(cudaMallocManaged(&d_camera_visible_points_count_ptr, num_cameras * sizeof(float)));
+    CUDA_CHECK(cudaMemset(d_camera_visible_points_count_ptr, 0, num_cameras * sizeof(float)));
+
+    // create a cublas handle
+    cublasHandle_t cublasH = NULL;
+    CUBLAS_CHECK(cublasCreate(&cublasH));
+
+    // --- Define scalar multipliers for GEMV ---
+    // C = alpha * A * B + beta * C
+    float alpha = 1.0f; // Multiply A*B by 1.0
+    float beta = 0.0f;  // Overwrite C, don't add to existing C
+
+    // --- Perform Matrix-Vector Multiplication using cublasSgemv ---
+    // Measure execution time
+    cudaEvent_t start_gemv, stop_gemv;
+    CUDA_CHECK(cudaEventCreate(&start_gemv));
+    CUDA_CHECK(cudaEventCreate(&stop_gemv));
+
+    printf("\nLaunching cublasSgemv...\n");
+    CUDA_CHECK(cudaEventRecord(start_gemv));
+
+    // Perform matrix-vector multiplication
+    CUBLAS_CHECK(cublasSgemv(cublasH,
+        CUBLAS_OP_N,        // A is row-major visibility matrix, do not transpose
+        num_cameras,        // number of rows of op(A)
+        num_points,         // number of columns of op(A)
+        &alpha,             // scalar multiplier for A*x
+        visibility_matrix,  // pointer to matrix A
+        num_cameras,        // leading dimension of original A (number of columns in row-major)
+        vector_reduction,   // pointer to vector x
+        1,                  // stride for vector x (contiguous), 1 means contiguous
+        &beta,              // scalar multiplier for beta*C, not used here, thus vector_bias is NULL
+        d_camera_visible_points_count_ptr,        // output place
+        1));                // stride for vector C (contiguous)
+
+    CUDA_CHECK(cudaEventRecord(stop_gemv));
+    CUDA_CHECK(cudaEventSynchronize(stop_gemv));
+
+    float gemv_milliseconds = 0;
+    CUDA_CHECK(cudaEventElapsedTime(&gemv_milliseconds, start_gemv, stop_gemv));
+    printf("Kernel execution time for matrix-vector multiplication: %f ms\n", gemv_milliseconds);
 
     // 3. find candidate cameras for final coverage selection
     cudaEvent_t start_candidate, stop_candidate;
@@ -78,8 +130,8 @@ void Coverage::getVisibilityMatrixKernel(
     int candidate_blockSize = 256;
     int candidate_gridSize = (num_points + candidate_blockSize - 1) / candidate_blockSize;
 
-    std::cout << "\nStarting CUDA Kernel to find candidate cameras..." << std::endl;
-    std::cout << "    Grid size: " << candidate_gridSize << ", block size: " << candidate_blockSize << std::endl;
+    printf("\nStarting CUDA Kernel to find candidate cameras...\n");
+    printf("    Grid size: %d, block size: %d\n", candidate_gridSize, candidate_blockSize);
 
     CUDA_CHECK(cudaEventRecord(start_candidate));
     findCandidateCameraKernel<<<candidate_gridSize, candidate_blockSize>>>(
@@ -94,7 +146,12 @@ void Coverage::getVisibilityMatrixKernel(
 
     float candidate_milliseconds = 0;
     CUDA_CHECK(cudaEventElapsedTime(&candidate_milliseconds, start_candidate, stop_candidate));
-    std::cout << "Kernel execution time for finding candidate cameras: " << candidate_milliseconds << " ms" << std::endl;
+    printf("Kernel execution time for finding candidate cameras: %f ms\n", candidate_milliseconds);
+
+    // 4. free the memory
+    CUDA_CHECK(cudaFree(vector_reduction));
+    CUDA_CHECK(cudaFree(d_camera_visible_points_count_ptr));
+    CUBLAS_CHECK(cublasDestroy(cublasH));
 }
 
 __device__ bool Coverage::is_point_visible(
@@ -151,7 +208,7 @@ __global__ void Coverage::generateVisibilityMatrixKernel(
     const float* __restrict__ d_extrinsics_array, // camera extrinsics
     const float3* __restrict__ d_points_array, // 3D points
     const float* __restrict__ d_depth_maps, // depth maps array
-    unsigned char* __restrict__ d_visibility_matrix, // output visibility matrix
+    float* __restrict__ d_visibility_matrix, // output visibility matrix
     int num_cameras, // number of cameras
     int num_points) { // number of points
 
@@ -162,49 +219,6 @@ __global__ void Coverage::generateVisibilityMatrixKernel(
     for (; global_index < total_combinations; global_index += blockDim.x * gridDim.x) {
         int camera_index = global_index / num_points;
         int point_index = global_index % num_points;
-
-        // for debugging, print the critical informations, ensure the information is printed once
-        // if (camera_index == 0 && point_index == 0) {
-        //     printf("intrinsic on gpu: %f, %f, %f, %f, %f, %f, should be interpreted as fx, fy, cx, cy, img_width, img_height\n", d_intrinsic[0], d_intrinsic[1], d_intrinsic[2], d_intrinsic[3], d_intrinsic[4], d_intrinsic[5]);
-        //     printf("first two extrinsics on gpu: %f, %f, %f, %f, %f, %f, %f, %f, %f, %f, %f, %f\n", d_extrinsics_array[0], d_extrinsics_array[1], d_extrinsics_array[2], d_extrinsics_array[3], d_extrinsics_array[4], d_extrinsics_array[5], d_extrinsics_array[6], d_extrinsics_array[7], d_extrinsics_array[8], d_extrinsics_array[9], d_extrinsics_array[10], d_extrinsics_array[11]);
-        //     printf("   second extrinsics on gpu: %f, %f, %f, %f, %f, %f, %f, %f, %f, %f, %f, %f\n", d_extrinsics_array[12], d_extrinsics_array[13], d_extrinsics_array[14], d_extrinsics_array[15], d_extrinsics_array[16], d_extrinsics_array[17], d_extrinsics_array[18], d_extrinsics_array[19], d_extrinsics_array[20], d_extrinsics_array[21], d_extrinsics_array[22], d_extrinsics_array[23]);
-        //     printf("first two points(world coordinates) on gpu: %f, %f, %f, %f, %f, %f\n", d_points_array[0].x, d_points_array[0].y, d_points_array[0].z, d_points_array[1].x, d_points_array[1].y, d_points_array[1].z);
-        // }
-        // 2. get camera extrinsics, get the rotation matrix and translation vector manually
-        // for debugging, print the critical informations, ensure the information is printed once
-        // if (camera_index == 1 && point_index == 0) {
-        //     printf("R_cw on gpu: %f, %f, %f, %f, %f, %f, %f, %f, %f\n", d_R_cw[0], d_R_cw[1], d_R_cw[2], d_R_cw[3], d_R_cw[4], d_R_cw[5], d_R_cw[6], d_R_cw[7], d_R_cw[8]);
-        //     printf("t_cw on gpu: %f, %f, %f\n", d_t_cw[0], d_t_cw[1], d_t_cw[2]);
-        // }
-        // 3. get 3D point
-        // if (camera_index == 0 && point_index == 0) {
-        //     printf("First point's coordinates: (%f, %f, %f)\n", point_world.x, point_world.y, point_world.z);
-        // }
-        // float3 point_camera;
-        // point_camera.x = d_R_cw[0] * point_world.x + d_R_cw[1] * point_world.y + d_R_cw[2] * point_world.z + d_t_cw[0];
-        // point_camera.y = d_R_cw[3] * point_world.x + d_R_cw[4] * point_world.y + d_R_cw[5] * point_world.z + d_t_cw[1];
-        // point_camera.z = d_R_cw[6] * point_world.x + d_R_cw[7] * point_world.y + d_R_cw[8] * point_world.z + d_t_cw[2];
-        // if (1) {
-        //     // 3. project 3D point to uv coordinates, u = fx * (px_cam / pz_cam) + cx, v = fy * (py_cam / pz_cam) + cy
-        //     float u = d_intrinsic[0] * (point_camera.x / point_camera.z) + d_intrinsic[2];
-        //     float v = d_intrinsic[1] * (point_camera.y / point_camera.z) + d_intrinsic[3];
-        //     printf("u: %f, v: %f, z: %f\n", u, v, point_camera.z);
-        // }
-        // for debugging, prechecking z value in camera coordinate system
-        // float3 point_camera;
-        // point_camera.x = d_R_cw[0] * point_world.x + d_R_cw[1] * point_world.y + d_R_cw[2] * point_world.z + d_t_cw[0];
-        // point_camera.y = d_R_cw[3] * point_world.x + d_R_cw[4] * point_world.y + d_R_cw[5] * point_world.z + d_t_cw[1];
-        // point_camera.z = d_R_cw[6] * point_world.x + d_R_cw[7] * point_world.y + d_R_cw[8] * point_world.z + d_t_cw[2];
-        // if (point_camera.z > 0) {
-        //     printf("point %d is visible in camera %d\n", point_index, camera_index);
-        // }
-        // if (camera_index == 10 && point_index == 94775) {
-        //     printf("camera 10's rotation: %f, %f, %f, %f, %f, %f, %f, %f, %f\n", d_R_cw[0], d_R_cw[1], d_R_cw[2], d_R_cw[3], d_R_cw[4], d_R_cw[5], d_R_cw[6], d_R_cw[7], d_R_cw[8]);
-        //     printf("camera 10's translation: %f, %f, %f\n", d_t_cw[0], d_t_cw[1], d_t_cw[2]);
-        //     printf("point world coordinates: %f, %f, %f\n", point_world.x, point_world.y, point_world.z);
-        //     printf("point camera coordinates: %f, %f, %f\n", point_camera.x, point_camera.y, point_camera.z);
-        // }
-        // 4. check if the point is visible
         
         const float* d_T_cw = d_extrinsics_array + camera_index * 12;
         float d_R_cw[9];
@@ -236,9 +250,9 @@ __global__ void Coverage::generateVisibilityMatrixKernel(
 }
 
 __global__ void Coverage::findCandidateCameraKernel(
-    const unsigned char* __restrict__ d_visibility_matrix,
-    const int* __restrict__ d_camera_visible_points_count,
-    int* __restrict__ d_point_candidate_camera_index,
+    float* __restrict__ d_visibility_matrix,
+    const float* __restrict__ d_camera_visible_points_count,
+    int* __restrict__ d_point_candidate_camera_index, // not necessary, actually can be removed.
     unsigned int* __restrict__ d_candidate_camera_mask,
     int num_cameras,
     int num_points) {
@@ -248,13 +262,13 @@ __global__ void Coverage::findCandidateCameraKernel(
 
     // incase the point index is bigger than the number of allocable threads, use the following loop to ensure the point is processed
     for (; point_index < total_points; point_index += blockDim.x * gridDim.x) {
-        int max_visible_count_for_point = -1; // stores the maximum numbr of visible points among cameras visible to the current point, -1 as initial value
+        float max_visible_count_for_point = -1; // stores the maximum numbr of visible points among cameras visible to the current point, -1 as initial value
         int candidate_camera_idx_for_pt = -1; // stores the index of the candidate camera chosen for the current point, -1 means no camera is chosen for the point
 
         for (int camera_idx = 0; camera_idx < num_cameras; camera_idx++) {
             if (d_visibility_matrix[camera_idx * num_points + point_index] == 1) {
                 // the camera is visible to the point, check the camera's visible points count
-                int current_camera_visible_count = d_camera_visible_points_count[camera_idx];
+                float current_camera_visible_count = d_camera_visible_points_count[camera_idx];
 
                 if (current_camera_visible_count > max_visible_count_for_point ||
                     (current_camera_visible_count == max_visible_count_for_point && 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -108,7 +108,7 @@ int main(int argc, char** argv) {
 
     // for debugging, to check the GPU performance
     // for (int test = 0; test < 100; test++) {
-    //     Coverage::getVisibilityMatrixKernel(cam.float_intrinsic_, cam.float_extrinsic_, vertexes.data(), depth.depth_maps_float_, num_cameras, num_points, visibility_matrix, candidate_camera_mask);
+    //     Coverage::getVisibilityMatrixKernel(cam.unified_float_intrinsic_, cam.unified_float_extrinsic_, mesh.unified_float_vertices_, depth.unified_float_depth_maps_, num_cameras, num_points, visibility_matrix, candidate_camera_mask, point_candidate_camera_index);
     // }
 
     // for debugging, check how many cameras are selected as candidate

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,6 +5,7 @@
 #include <cuda_runtime.h>
 #include <iostream> 
 #include <fstream>
+#include <cassert>
 #include <experimental/filesystem>
 
 // Simple helper to print usage information
@@ -78,34 +79,33 @@ int main(int argc, char** argv) {
     }
 
     MeshProcessing::Mesh mesh;
-    mesh.loadFromFile(mesh_path);
-    std::vector<float3> vertexes = mesh.getVertexes();
-    std::cout << "Vertexes number rechecked: " << vertexes.size() << std::endl;
-
+    mesh.loadFromFile_jetson(mesh_path);
+    int num_points = mesh.vertex_num_;
+    
     Camera::Cam cam;
-    cam.loadIntrinsic(intrinsic_path);
-    cam.loadExtrinsics_colormap(extrinsic_path);
-    cam.dump_intrinsic_to_float(); // prepare for the data loading of gpu
-    // dump has been checked, and the data is correct
-    cam.dump_extrinsic_to_float();
-
+    cam.loadIntrinsic_jetson(intrinsic_path);
+    cam.loadExtrinsics_colormap_jetson(extrinsic_path);
+    int num_cameras = cam.number_extrinsics;
+    
     Depth::Depth depth;
-    depth.loadDepthMaps(depth_dir);
-    depth.convertToFloat();
-
-    // for debugging, to check the camera extrinsics number 10
-    // std::cout << "camera 10's extrinsic: " << std::endl;
-    // std::cout << cam.extrinsics_[10].T_cw << std::endl;
+    depth.loadDepthMaps_jetson(depth_dir);
+    int num_depth_maps = depth.depth_map_num_;
+    
+    assert(num_depth_maps == num_cameras && "number of depth maps should be equal to number of cameras");
 
     // for convenience
-    int num_cameras = cam.extrinsics_.size();
-    int num_points = vertexes.size();
-
     unsigned char* visibility_matrix;
-    visibility_matrix = new unsigned char[num_cameras * num_points];
+    CUDA_CHECK(cudaMallocManaged(&visibility_matrix, sizeof(unsigned char) * num_cameras * num_points));
+    CUDA_CHECK(cudaMemset(visibility_matrix, 0, sizeof(unsigned char) * num_cameras * num_points));
+    int* point_candidate_camera_index;
+    CUDA_CHECK(cudaMallocManaged((void**)&point_candidate_camera_index, num_points * sizeof(int)));
+    CUDA_CHECK(cudaMemset(point_candidate_camera_index, -1, num_points * sizeof(int)));
+    unsigned int* candidate_camera_mask;
+    CUDA_CHECK(cudaMallocManaged((void**)&candidate_camera_mask, num_cameras * sizeof(unsigned int)));
+    CUDA_CHECK(cudaMemset(candidate_camera_mask, 0, num_cameras * sizeof(unsigned int)));
 
-    unsigned int* candidate_camera_mask = new unsigned int[num_cameras];
-    Coverage::getVisibilityMatrixKernel(cam.float_intrinsic_, cam.float_extrinsic_, vertexes.data(), depth.depth_maps_float_, num_cameras, num_points, visibility_matrix, candidate_camera_mask);
+    // get the visibility matrix
+    Coverage::getVisibilityMatrixKernel(cam.unified_float_intrinsic_, cam.unified_float_extrinsic_, mesh.unified_float_vertices_, depth.unified_float_depth_maps_, num_cameras, num_points, visibility_matrix, candidate_camera_mask, point_candidate_camera_index);
     std::cout << "coverage selection finished" << std::endl;
 
     // for debugging, to check the GPU performance

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -109,9 +109,9 @@ int main(int argc, char** argv) {
     std::cout << "coverage selection finished" << std::endl;
 
     // for debugging, to check the GPU performance
-    for (int test = 0; test < 100; test++) {
-        Coverage::getVisibilityMatrixKernel(cam.float_intrinsic_, cam.float_extrinsic_, vertexes.data(), depth.depth_maps_float_, num_cameras, num_points, visibility_matrix, candidate_camera_mask);
-    }
+    // for (int test = 0; test < 100; test++) {
+    //     Coverage::getVisibilityMatrixKernel(cam.float_intrinsic_, cam.float_extrinsic_, vertexes.data(), depth.depth_maps_float_, num_cameras, num_points, visibility_matrix, candidate_camera_mask);
+    // }
 
     // for debugging, check how many cameras are selected as candidate
     int num_candidate_cameras = 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -109,9 +109,9 @@ int main(int argc, char** argv) {
     std::cout << "coverage selection finished" << std::endl;
 
     // for debugging, to check the GPU performance
-    // for (int test = 0; test < 5000; test++) {
-    //     Coverage::getVisibilityMatrixKernel(cam.float_intrinsic_, cam.float_extrinsic_, vertexes.data(), depth.depth_maps_float_, num_cameras, num_points, visibility_matrix, candidate_camera_mask);
-    // }
+    for (int test = 0; test < 100; test++) {
+        Coverage::getVisibilityMatrixKernel(cam.float_intrinsic_, cam.float_extrinsic_, vertexes.data(), depth.depth_maps_float_, num_cameras, num_points, visibility_matrix, candidate_camera_mask);
+    }
 
     // for debugging, check how many cameras are selected as candidate
     int num_candidate_cameras = 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -94,12 +94,10 @@ int main(int argc, char** argv) {
     assert(num_depth_maps == num_cameras && "number of depth maps should be equal to number of cameras");
 
     // for convenience
-    unsigned char* visibility_matrix;
-    CUDA_CHECK(cudaMallocManaged(&visibility_matrix, sizeof(unsigned char) * num_cameras * num_points));
-    CUDA_CHECK(cudaMemset(visibility_matrix, 0, sizeof(unsigned char) * num_cameras * num_points));
+    float* visibility_matrix;
+    CUDA_CHECK(cudaMallocManaged(&visibility_matrix, sizeof(float) * num_cameras * num_points));
     int* point_candidate_camera_index;
     CUDA_CHECK(cudaMallocManaged((void**)&point_candidate_camera_index, num_points * sizeof(int)));
-    CUDA_CHECK(cudaMemset(point_candidate_camera_index, -1, num_points * sizeof(int)));
     unsigned int* candidate_camera_mask;
     CUDA_CHECK(cudaMallocManaged((void**)&candidate_camera_mask, num_cameras * sizeof(unsigned int)));
     CUDA_CHECK(cudaMemset(candidate_camera_mask, 0, num_cameras * sizeof(unsigned int)));


### PR DESCRIPTION
This branch will not be merged. It has some slight configuration changes for the Jetson Platform. I suspect that Jetson itself has some hardware/drive optimization to make CUDA memory copy from CPU to GPU fast and with no extra cost. Here, I just run the basic test and do not change the CUDA code significantly from the 4090. And I've had a robust result. In my test, I run on Jetson Orin Nano 8GB platform with computation timing cost for now (three kernel event time usage: 198ms+166ms+26ms for ordinary scenes(2*4*2m underground scene)， a big scene with 100~200 m^2， the total time usage for computation is still less than 500ms)